### PR TITLE
[feat]: 사용자 역할 간 페이지 접근 금지(#30)

### DIFF
--- a/src/authStore.ts
+++ b/src/authStore.ts
@@ -1,0 +1,40 @@
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware'; // 로컬/세션 스토리지 연동 (선택 사항)
+
+// 사용자 역할 타입 정의 (null 포함)
+export type UserRole = 'student' | 'instructor' | 'admin' | null;
+
+interface AuthState {
+  isAuthenticated: boolean;
+  userRole: UserRole;
+  token: string | null; // Firebase 또는 API 토큰 저장
+  setAuthState: (data: { isAuthenticated: boolean; userRole: UserRole; token: string | null }) => void;
+  logout: () => void;
+}
+
+// persist 미들웨어 사용 예시 (localStorage에 저장)
+export const useAuthStore = create<AuthState>()(
+  persist(
+    (set) => ({
+      isAuthenticated: false,
+      userRole: null,
+      token: null,
+      setAuthState: (data) => set({
+        isAuthenticated: data.isAuthenticated,
+        userRole: data.userRole,
+        token: data.token,
+      }),
+      logout: () => {
+        // TODO: 필요시 Firebase 로그아웃 추가
+        // import { signOut } from "firebase/auth";
+        // import { auth } from "../firebase"; // 경로 주의
+        // signOut(auth).catch(error => console.error("Firebase signout error:", error));
+        set({ isAuthenticated: false, userRole: null, token: null });
+        // TODO: 로그아웃 후 로그인 페이지로 이동 로직 추가 (컴포넌트 내에서 navigate 사용 권장)
+      },
+    }),
+    {
+      name: 'auth-storage', // localStorage에 저장될 때 사용될 키 이름
+    }
+  )
+);

--- a/src/components/Router.tsx
+++ b/src/components/Router.tsx
@@ -1,95 +1,118 @@
+// router.ts (또는 .js)
 import React from "react";
-import { createBrowserRouter } from "react-router-dom";
-import Root from "./Root";
+import { createBrowserRouter, Navigate, Outlet } from "react-router-dom"; // Navigate, Outlet 추가
+import Root from "./Root"; // Root 컴포넌트가 무엇인지 확인 필요
 
-//인증
+// 인증 페이지
 import RegisterPage from "../screen/RegisterPage";
 import LoginPage from "../screen/LoginPage";
 
-//메인(Nav)
+// 레이아웃 (Main 컴포넌트들)
 import StudentMain from "../screen/student/Main";
 import LecturerMain from "../screen/instructor/Main";
+// import AdminMain from "../screen/admin/Main"; // TODO: 관리자 레이아웃
 
-//학생 페이지
+// 학생 페이지
 import StudentDashBoard from "../screen/student/Dashboard"
 import StudentLectures from "../screen/student/Lectures";
 import Analysis from "../screen/student/Monitoring";
 import StudentSetting from "../screen/student/Setting";
 
-//교수자 페이지
+// 교수자 페이지
 import InstructorCourses from "../screen/instructor/Lectures";
 import InstructorSetting from "../screen/instructor/Setting";
 import RecordingList from "../screen/instructor/RecordingList";
 import RecordingDetail from "../screen/instructor/RecordingDetail";
 
+// TODO: 관리자 페이지 컴포넌트 import
 
-//todo admin페이지 구현..
+// 보호 라우트 컴포넌트 import
+import ProtectedRoute from "../components/auth/ProtectedRoute"; // 경로 확인
+import RoleProtectedRoute from "../components/auth/RoleProtectedRoute"; // 경로 확인
 
 const router = createBrowserRouter([
+  // --- 공개 라우트 ---
+  {
+    path: "/login",
+    element: <LoginPage />,
+  },
+  {
+    path: "/register",
+    element: <RegisterPage />,
+  },
   {
     path: "/",
     element: <Root />,
-    children:[
-      {
-        path:"login",
-        element: <LoginPage />
-      },
-      {
-        path:"register",
-        element: <RegisterPage />
-      }
-    ]
   },
+
+  // --- 보호 라우트 (로그인 필수) ---
   {
-    //학생용 화면
-    path: "/student",
-    element: <StudentMain />,
+    element: <ProtectedRoute />, // 1단계: 로그인 여부 체크
     children: [
+      // --- 학생 전용 라우트 ---
       {
-        path: "dashboard",
-        element: <StudentDashBoard />
-      },
-      {
-        path: "courses",
-        element: <StudentLectures />,
-      },
-      {
-        path: "monitoring",
-        element: <Analysis />
-      },
-      {
-        path: "setting",
-        element: <StudentSetting />
-      }
-    ],
-  },
-  {
-    // 교수자용 화면
-    path: "/instructor",
-    element: <LecturerMain />,
-    children: [ 
-      {
-        path: "courses",
-        element: <InstructorCourses/>
-      },
-      {
-        path: "recording",
+        element: <RoleProtectedRoute allowedRoles={['student']} />,
         children: [
           {
-            index: true,
-            element: <RecordingList />
+            path: "/student",
+            element: <StudentMain />,
+            children: [
+              { path: "dashboard", element: <StudentDashBoard /> },
+              { path: "courses", element: <StudentLectures /> },
+              { path: "monitoring", element: <Analysis /> },
+              { path: "setting", element: <StudentSetting /> },
+              // /student 기본 경로 -> dashboard로 리디렉션
+              { index: true, element: <Navigate to="dashboard" replace /> }
+            ],
           },
+        ]
+      },
+      // --- 강의자 전용 라우트 ---
+      {
+        element: <RoleProtectedRoute allowedRoles={['instructor']} />, 
+        children: [
           {
-            path: ":id",
-            element: <RecordingDetail />
+            path: "/instructor",
+            element: <LecturerMain />,
+            children: [
+              { path: "courses", element: <InstructorCourses/> },
+              {
+                path: "recording",
+                children: [
+                  { index: true, element: <RecordingList /> }, // /instructor/recording
+                  { path: ":id", element: <RecordingDetail /> } // /instructor/recording/:id
+                ]
+              },
+              { path: "setting", element: <InstructorSetting /> },
+               // /instructor 기본 경로 -> courses로 리디렉션
+              { index: true, element: <Navigate to="courses" replace /> }
+            ],
           }
         ]
       },
-      {
-        path: "setting",
-        element: <InstructorSetting />
-      }
-    ]
-  }
+      // --- 관리자 전용 라우트 (TODO) ---
+      // {
+      //   element: <RoleProtectedRoute allowedRoles={['admin']} />, // 2단계: 관리자 역할 체크
+      //   children: [
+      //     {
+      //       path: "/admin",
+      //       element: <AdminMain />, // 관리자 레이아웃
+      //       children: [
+      //         // ... 관리자 페이지 라우트 ...
+      //         { index: true, element: <Navigate to="some-admin-page" replace /> }
+      //       ]
+      //     }
+      //   ]
+      // },
+
+      // --- 모든 로그인 사용자가 접근 가능한 공통 라우트 (선택 사항) ---
+      // { path: "/profile", element: <UserProfile /> }
+
+    ] // ProtectedRoute children 끝
+  }, // ProtectedRoute 끝
+
+  // --- 404 Not Found (맨 마지막에 위치) ---
+  // { path: "*", element: <NotFound /> }
 ]);
+
 export default router;

--- a/src/components/auth/Login.tsx
+++ b/src/components/auth/Login.tsx
@@ -4,6 +4,7 @@ import { useNavigate } from "react-router-dom"; // For redirection after login
 import { signInWithEmailAndPassword } from "firebase/auth";
 import { auth } from "../../../src/firebase"; // Firebase auth for student login
 import { useThemeStore } from "../../store"; // Assuming theme state is needed
+import { useAuthStore } from '../../authStore';
 
 // --- Reusable Styled Components (Can be imported from a shared file or defined here) ---
 // Using similar components as Register for consistency
@@ -206,6 +207,7 @@ export default function Login() {
   const handleShowPassword = () => setShowPassword(true);
   const handleHidePassword = () => setShowPassword(false);
 
+  const { setAuthState } = useAuthStore();
   const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     setError("");
@@ -279,10 +281,12 @@ export default function Login() {
             throw new Error(verifyApiError);
           }
 
+          if (!verifyResponse.ok) { /* ... */ throw new Error(/* ... */); }
           console.log("Student Login and Token Verification Successful!");
-          // TODO: Store necessary student user data/token from verifyResponse if needed
-          // TODO: Redirect to student dashboard
-          navigate('/student/dashboard'); // Example redirect
+          // !!! 로그인 성공 시 상태 저장 !!!
+          setAuthState({ isAuthenticated: true, userRole: 'student', token: token });
+          navigate('/student/dashboard'); // 리디렉션
+
           break;
 
         case 'instructor':
@@ -307,11 +311,12 @@ export default function Login() {
             throw new Error(instructorApiError);
           }
 
+          if (!instructorLoginResponse.ok) { /* ... */ throw new Error(/* ... */); }
           const instructorData = await instructorLoginResponse.json();
           console.log("Instructor Login Successful:", instructorData);
-           // TODO: Store necessary instructor token/data (e.g., instructorData.access_token)
-           // TODO: Redirect to instructor dashboard
-          navigate('/instructor/courses'); // Example redirect
+          // !!! 로그인 성공 시 상태 저장 !!! (API 응답에서 토큰 필드 확인 필요)
+          setAuthState({ isAuthenticated: true, userRole: 'instructor', token: instructorData.access_token || instructorData.token });
+          navigate('/instructor/courses'); // 리디렉션
           break;
 
         case 'admin':
@@ -337,11 +342,12 @@ export default function Login() {
             throw new Error(adminApiError);
           }
 
+          if (!adminLoginResponse.ok) { /* ... */ throw new Error(/* ... */); }
           const adminData = await adminLoginResponse.json();
           console.log("Admin Login Successful:", adminData);
-           // TODO: Store necessary admin token/data
-           // TODO: Redirect to admin dashboard
-          navigate('/admin/user/student'); // Example redirect
+          // !!! 로그인 성공 시 상태 저장 !!! (API 응답에서 토큰 필드 확인 필요)
+          setAuthState({ isAuthenticated: true, userRole: 'admin', token: adminData.access_token || adminData.token });
+          navigate('/admin/user/student'); // 리디렉션
           break;
 
         case 'none':

--- a/src/components/auth/ProtectedRoute.tsx
+++ b/src/components/auth/ProtectedRoute.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { Navigate, Outlet, useLocation } from 'react-router-dom';
+import { useAuthStore } from '../../authStore'; // 경로 확인
+
+const ProtectedRoute = () => {
+  const isAuthenticated = useAuthStore((state) => state.isAuthenticated);
+  const location = useLocation(); // 현재 경로 저장 (로그인 후 리디렉션용)
+
+  if (!isAuthenticated) {
+    // 로그인 안됨 -> 로그인 페이지로 리디렉션, 현재 경로는 state로 전달
+    return <Navigate to="/login" state={{ from: location }} replace />;
+  }
+
+  // 로그인 됨 -> 자식 라우트 렌더링
+  return <Outlet />;
+};
+
+export default ProtectedRoute;

--- a/src/components/auth/RoleProtectedRoute.tsx
+++ b/src/components/auth/RoleProtectedRoute.tsx
@@ -1,0 +1,33 @@
+// src/components/auth/RoleProtectedRoute.tsx (수정)
+import React from 'react';
+import { Navigate, Outlet, useLocation } from 'react-router-dom';
+import { useAuthStore, UserRole } from '../../authStore'; // 경로 확인
+
+interface RoleProtectedRouteProps {
+  allowedRoles: UserRole[];
+}
+
+const RoleProtectedRoute: React.FC<RoleProtectedRouteProps> = ({ allowedRoles }) => {
+  const isAuthenticated = useAuthStore((state) => state.isAuthenticated);
+  const userRole = useAuthStore((state) => state.userRole);
+  const location = useLocation();
+
+  // 1. 로그인 여부 확인
+  if (!isAuthenticated) {
+    // 로그인 안됨 -> 로그인 페이지로 리디렉션
+    return <Navigate to="/login" state={{ from: location }} replace />;
+  }
+
+  // 2. 역할 확인
+  if (!userRole || !allowedRoles.includes(userRole)) {
+    console.warn(`RoleProtectedRoute: Role '${userRole}' not allowed for this route. Redirecting to /login.`);
+    // 역할이 없거나 허용되지 않음 -> 로그인 페이지로 리디렉션 (unauthorized 대신)
+    // 접근하려던 페이지 정보를 state로 넘겨서 로그인 후 이동시킬 수도 있음
+    return <Navigate to="/login" state={{ from: location, unauthorized: true }} replace />;
+  }
+
+  // 3. 허용됨 -> 자식 라우트 렌더링
+  return <Outlet />;
+};
+
+export default RoleProtectedRoute;

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -6,9 +6,9 @@ export const darktheme: DefaultTheme = {
   backgroundColor: "#353b48",
   btnColor: "#7f8fa6",
   hoverBtnColor:"#718093",
-  formContainerColor: "#718093",
+  formContainerColor: "#2f3640",
 
-  navBackgroundColor:"#2f3640",
+  navBackgroundColor:"#1e272e",
   highlightColor:"#dcdde1",
 };
 


### PR DESCRIPTION
## 👀 이슈
resolve #30 

## 📌 개요
사용자 역할(학생, 강의자, 관리자)에 따라 각 역할 간 페이지 접근 금지 기능 추가

## 👩‍💻 작업 사항

- ProtectedRoute를 통해 인증 안된 사용자의 접근을 막는다
- 사용자 역할에 대한 정보는 authStore.ts에서 전역으로 관리한다
- 위 변경에 따른 Router.tsx변경