### PR TITLE
[feat]: 로그인 기능 추가 구현(#20)

### DIFF
--- a/src/api/apiClient.ts
+++ b/src/api/apiClient.ts
@@ -1,0 +1,161 @@
+//api사용 시 apiClient.get이런식으로 호출해야 함
+import axios, { AxiosError, InternalAxiosRequestConfig } from "axios";
+import { useAuthStore } from "../authStore"; // Zustand 스토어 import 경로 확인
+
+const apiClient = axios.create({
+  baseURL: "http://127.0.0.1:8000/api/v1",
+  headers: {
+    "Content-Type": "application/json",
+    accept: "application/json",
+  },
+});
+
+// --- 요청 인터셉터 (변경 없음) ---
+apiClient.interceptors.request.use(
+  (config: InternalAxiosRequestConfig) => {
+    const { accessToken } = useAuthStore.getState();
+    if (accessToken && config.headers && !config.headers.Authorization) {
+      config.headers.Authorization = `Bearer ${accessToken}`;
+    }
+    return config;
+  },
+  (error) => Promise.reject(error)
+);
+
+// --- 응답 인터셉터 (수정) ---
+let isRefreshing = false;
+let failedQueue: {
+  resolve: (value: unknown) => void;
+  reject: (reason?: any) => void;
+}[] = [];
+
+const processQueue = (error: Error | null, token: string | null = null) => {
+  failedQueue.forEach((prom) => {
+    if (error) {
+      prom.reject(error); // 이제 일반 Error 타입도 받을 수 있음
+    } else {
+      prom.resolve(token);
+    }
+  });
+  failedQueue = [];
+};
+
+apiClient.interceptors.response.use(
+  (response) => response,
+  async (error: AxiosError) => {
+    const originalRequest = error.config as InternalAxiosRequestConfig & {
+      _retry?: boolean;
+    };
+
+    // 401 에러이고, 재시도 요청이 아니며, 요청 설정이 있는 경우
+    if (
+      error.response?.status === 401 &&
+      !originalRequest._retry &&
+      originalRequest
+    ) {
+      if (isRefreshing) {
+        // 갱신 중 큐잉 로직 (변경 없음)
+        return new Promise((resolve, reject) => {
+          /* ... */
+        });
+      }
+
+      console.log(
+        "Original request failed with 401. Attempting token refresh."
+      );
+      originalRequest._retry = true;
+      isRefreshing = true;
+
+      // !!! 역할(Role)과 리프레시 토큰 가져오기 !!!
+      const { userRole, refreshToken, setTokens, logout } =
+        useAuthStore.getState();
+
+      if (!refreshToken) {
+        console.error("Refresh token not found. Logging out.");
+        logout();
+        isRefreshing = false;
+        processQueue(error, null);
+        return Promise.reject(error);
+      }
+
+      // !!! 역할(Role)에 따라 Refresh URL 결정 !!!
+      let refreshUrl = "";
+      switch (userRole) {
+        case "student":
+          refreshUrl = "/auth/refresh"; // 학생용 갱신 URL (상대 경로)
+          break;
+        case "instructor":
+          refreshUrl = "/instructors-auth/refresh"; // 강의자용 갱신 URL (상대 경로)
+          break;
+        case "admin":
+          refreshUrl = "/auth/admin-refresh"; // 관리자용 갱신 URL (상대 경로)
+          break;
+        default:
+          console.error(
+            `Unknown user role (${userRole}) for token refresh. Logging out.`
+          );
+          logout();
+          isRefreshing = false;
+          processQueue(new Error("Unknown user role for refresh"), null);
+          return Promise.reject(new Error("Unknown user role"));
+      }
+
+      try {
+        console.log(
+          `Attempting token refresh for role: ${userRole} at ${refreshUrl}`
+        );
+
+        // !!! 결정된 URL로 토큰 갱신 요청 !!!
+        const refreshResponse = await axios.post(
+          refreshUrl, // 동적으로 결정된 URL 사용
+          { refresh_token: refreshToken },
+          {
+            baseURL: apiClient.defaults.baseURL, // apiClient의 baseURL 사용 확인
+            headers: {
+              // 필요한 헤더 명시
+              accept: "application/json",
+              "Content-Type": "application/json",
+            },
+          }
+        );
+
+        const { access_token: newAccessToken, refresh_token: newRefreshToken } =
+          refreshResponse.data;
+
+        if (!newAccessToken) {
+          throw new Error("Refresh response did not contain new access token.");
+        }
+
+        console.log("Token refresh successful.");
+        // 스토어에 새 토큰 저장
+        setTokens({
+          accessToken: newAccessToken,
+          refreshToken: newRefreshToken || refreshToken,
+        });
+
+        // 원래 요청 헤더에 새 토큰 설정
+        if (originalRequest.headers) {
+          originalRequest.headers["Authorization"] = `Bearer ${newAccessToken}`;
+        }
+
+        processQueue(null, newAccessToken); // 큐 처리
+        return apiClient(originalRequest); // 원래 요청 재시도
+      } catch (refreshError: any) {
+        console.error(
+          "Failed to refresh token:",
+          refreshError?.response?.data || refreshError.message
+        );
+        logout(); // 리프레시 실패 시 로그아웃
+        processQueue(refreshError, null);
+        return Promise.reject(refreshError);
+      } finally {
+        isRefreshing = false;
+      }
+    }
+
+    // 401 에러가 아니거나 이미 재시도한 경우
+    return Promise.reject(error);
+  }
+);
+
+export default apiClient;

--- a/src/authStore.ts
+++ b/src/authStore.ts
@@ -1,40 +1,45 @@
+// src/store/authStore.ts (수정)
 import { create } from 'zustand';
-import { persist } from 'zustand/middleware'; // 로컬/세션 스토리지 연동 (선택 사항)
+import { persist } from 'zustand/middleware';
 
-// 사용자 역할 타입 정의 (null 포함)
 export type UserRole = 'student' | 'instructor' | 'admin' | null;
 
 interface AuthState {
   isAuthenticated: boolean;
   userRole: UserRole;
-  token: string | null; // Firebase 또는 API 토큰 저장
-  setAuthState: (data: { isAuthenticated: boolean; userRole: UserRole; token: string | null }) => void;
+  accessToken: string | null; // 백엔드 JWT Access Token
+  refreshToken: string | null; // 백엔드 JWT Refresh Token
+  // 토큰만 업데이트하는 액션 (토큰 갱신 시 사용)
+  setTokens: (tokens: { accessToken: string | null; refreshToken: string | null }) => void;
+  // 전체 인증 정보 설정 액션 (로그인 시 사용)
+  setAuthInfo: (data: { isAuthenticated: boolean; userRole: UserRole; accessToken: string | null; refreshToken: string | null }) => void;
   logout: () => void;
 }
 
-// persist 미들웨어 사용 예시 (localStorage에 저장)
 export const useAuthStore = create<AuthState>()(
   persist(
     (set) => ({
       isAuthenticated: false,
       userRole: null,
-      token: null,
-      setAuthState: (data) => set({
+      accessToken: null,
+      refreshToken: null,
+      setTokens: (tokens) => set({
+        accessToken: tokens.accessToken,
+        refreshToken: tokens.refreshToken,
+      }),
+      setAuthInfo: (data) => set({
         isAuthenticated: data.isAuthenticated,
         userRole: data.userRole,
-        token: data.token,
+        accessToken: data.accessToken,
+        refreshToken: data.refreshToken,
       }),
       logout: () => {
-        // TODO: 필요시 Firebase 로그아웃 추가
-        // import { signOut } from "firebase/auth";
-        // import { auth } from "../firebase"; // 경로 주의
-        // signOut(auth).catch(error => console.error("Firebase signout error:", error));
-        set({ isAuthenticated: false, userRole: null, token: null });
-        // TODO: 로그아웃 후 로그인 페이지로 이동 로직 추가 (컴포넌트 내에서 navigate 사용 권장)
+        // TODO: 필요시 Firebase 로그아웃
+        set({ isAuthenticated: false, userRole: null, accessToken: null, refreshToken: null });
       },
     }),
     {
-      name: 'auth-storage', // localStorage에 저장될 때 사용될 키 이름
+      name: 'auth-storage', // 스토리지 키 이름
     }
   )
 );

--- a/src/components/auth/Login.tsx
+++ b/src/components/auth/Login.tsx
@@ -207,7 +207,7 @@ export default function Login() {
   const handleShowPassword = () => setShowPassword(true);
   const handleHidePassword = () => setShowPassword(false);
 
-  const { setAuthState } = useAuthStore();
+  const { setAuthInfo } = useAuthStore(); // setAuthInfo 
   const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     setError("");
@@ -252,108 +252,127 @@ export default function Login() {
       switch (userRole) {
         case 'student':
           console.log("Attempting Student Login via Firebase...");
-          // Firebase Login
           const userCredential = await signInWithEmailAndPassword(auth, email, pw);
           console.log("Firebase Login Success:", userCredential.user.uid);
-
-          // Get Firebase ID Token
-          const token = await userCredential.user.getIdToken();
+          const firebaseIdToken = await userCredential.user.getIdToken(); // Firebase ID 토큰
           console.log("Firebase ID Token obtained.");
-
+          console.log(firebaseIdToken);
+          
           // Verify Token with Backend
           const verifyResponse = await fetch('http://127.0.0.1:8000/api/v1/auth/verify-token', {
             method: 'POST',
             headers: {
               'accept': 'application/json',
-              'Authorization': `Bearer ${token}`,
+              'Authorization': `Bearer ${firebaseIdToken}`, // Firebase ID 토큰 전달
             },
-             // No body needed according to curl example
           });
 
-          if (!verifyResponse.ok) {
-             let verifyApiError = '토큰 인증 실패';
-             try {
-                 const errorData = await verifyResponse.json();
-                 verifyApiError = errorData.detail || JSON.stringify(errorData);
-             } catch (jsonError) {
-                 verifyApiError = `HTTP Error ${verifyResponse.status}: ${verifyResponse.statusText}`;
-             }
-            throw new Error(verifyApiError);
+          if (!verifyResponse.ok) { /* ... 토큰 교환 에러 처리 ... */ throw new Error(/* ... */); }
+
+          // 백엔드로부터 access/refresh 토큰 받기
+          const backendTokenData = await verifyResponse.json();
+          console.log("Backend Token Exchange Successful:", backendTokenData);
+
+          if (!backendTokenData.access_token || !backendTokenData.refresh_token) {
+              throw new Error("백엔드 토큰 정보가 응답에 없습니다.");
           }
 
-          if (!verifyResponse.ok) { /* ... */ throw new Error(/* ... */); }
-          console.log("Student Login and Token Verification Successful!");
-          // !!! 로그인 성공 시 상태 저장 !!!
-          setAuthState({ isAuthenticated: true, userRole: 'student', token: token });
-          navigate('/student/dashboard'); // 리디렉션
-
-          break;
-
-        case 'instructor':
-          console.log("Attempting Instructor Login via API...");
-          const instructorLoginResponse = await fetch('http://127.0.0.1:8000/api/v1/instructors-auth/login', {
-            method: 'POST',
-            headers: {
-              'accept': 'application/json',
-              'Content-Type': 'application/json',
-            },
-            body: JSON.stringify({ email: email, password: pw }),
+          // !!! Zustand 스토어에 백엔드 토큰 저장 !!!
+          setAuthInfo({
+            isAuthenticated: true,
+            userRole: 'student',
+            accessToken: backendTokenData.access_token, // 백엔드 Access Token
+            refreshToken: backendTokenData.refresh_token // 백엔드 Refresh Token
           });
-
-          if (!instructorLoginResponse.ok) {
-             let instructorApiError = '강의자 로그인 실패';
-             try {
-                 const errorData = await instructorLoginResponse.json();
-                 instructorApiError = errorData.detail || JSON.stringify(errorData);
-             } catch (jsonError) {
-                  instructorApiError = `HTTP Error ${instructorLoginResponse.status}: ${instructorLoginResponse.statusText}`;
-             }
-            throw new Error(instructorApiError);
-          }
-
-          if (!instructorLoginResponse.ok) { /* ... */ throw new Error(/* ... */); }
-          const instructorData = await instructorLoginResponse.json();
-          console.log("Instructor Login Successful:", instructorData);
-          // !!! 로그인 성공 시 상태 저장 !!! (API 응답에서 토큰 필드 확인 필요)
-          setAuthState({ isAuthenticated: true, userRole: 'instructor', token: instructorData.access_token || instructorData.token });
-          navigate('/instructor/courses'); // 리디렉션
+          navigate('/student/dashboard');
           break;
 
-        case 'admin':
-          console.log("Attempting Admin Login via API...");
-           const adminLoginResponse = await fetch('http://127.0.0.1:8000/api/v1/auth/admin-login', {
-            method: 'POST',
-            headers: {
-              'accept': 'application/json',
-              'Content-Type': 'application/json',
-            },
-            // Using email as username as implied
-            body: JSON.stringify({ username: email, password: pw }),
-          });
+          case 'instructor':
+            console.log("Attempting Instructor Login via API...");
+            const instructorLoginResponse = await fetch('http://127.0.0.1:8000/api/v1/instructors-auth/login', {
+              method: 'POST',
+              headers: {
+                'accept': 'application/json',
+                'Content-Type': 'application/json',
+              },
+              // 요청 Body: email과 pw(password)를 전송 -> API 명세와 일치
+              body: JSON.stringify({ email: email, password: pw }),
+            });
+          
+            if (!instructorLoginResponse.ok) {
+              // API 에러 처리 로직 (기존과 동일)
+              let instructorApiError = '강의자 로그인 실패';
+              try {
+                  const errorData = await instructorLoginResponse.json();
+                  instructorApiError = errorData.detail || JSON.stringify(errorData);
+              } catch (jsonError) {
+                   instructorApiError = `HTTP Error ${instructorLoginResponse.status}: ${instructorLoginResponse.statusText}`;
+              }
+              throw new Error(instructorApiError);
+            }
+          
+            // 성공 응답 파싱
+            const instructorData = await instructorLoginResponse.json();
+            console.log("Instructor Login Successful:", instructorData);
+          
+            // 응답에서 access_token과 refresh_token 확인 -> API 명세와 일치
+            if (!instructorData.access_token || !instructorData.refresh_token) {
+                throw new Error("강의자 로그인 응답에 토큰 정보가 없습니다.");
+            }
+          
+            // Zustand 스토어에 상태 저장 -> API 명세의 필드 이름과 일치
+            setAuthInfo({
+                isAuthenticated: true,
+                userRole: 'instructor',
+                accessToken: instructorData.access_token,
+                refreshToken: instructorData.refresh_token
+            });
+            navigate('/instructor/courses'); // 리디렉션
+            break;
 
-           if (!adminLoginResponse.ok) {
-             let adminApiError = '관리자 로그인 실패';
-             try {
-                 const errorData = await adminLoginResponse.json();
-                 adminApiError = errorData.detail || JSON.stringify(errorData);
-             } catch (jsonError) {
-                 adminApiError = `HTTP Error ${adminLoginResponse.status}: ${adminLoginResponse.statusText}`;
-             }
-            throw new Error(adminApiError);
-          }
-
-          if (!adminLoginResponse.ok) { /* ... */ throw new Error(/* ... */); }
-          const adminData = await adminLoginResponse.json();
-          console.log("Admin Login Successful:", adminData);
-          // !!! 로그인 성공 시 상태 저장 !!! (API 응답에서 토큰 필드 확인 필요)
-          setAuthState({ isAuthenticated: true, userRole: 'admin', token: adminData.access_token || adminData.token });
-          navigate('/admin/user/student'); // 리디렉션
-          break;
-
-        case 'none':
-        default:
-          setError("등록되지 않은 사용자이거나 역할 정보가 없습니다.");
-          break;
+            case 'admin':
+              console.log("Attempting Admin Login via API...");
+              const adminLoginResponse = await fetch('http://127.0.0.1:8000/api/v1/auth/admin-login', {
+                method: 'POST',
+                headers: {
+                  'accept': 'application/json',
+                  'Content-Type': 'application/json',
+                },
+                // 요청 Body: email 상태값을 username으로, pw를 password로 전송
+                // API 명세의 username 필드에 email 값을 사용하는 것이 맞다면 현재 로직은 정확합니다.
+                body: JSON.stringify({ username: email, password: pw }),
+              });
+            
+              if (!adminLoginResponse.ok) {
+                // API 에러 처리 로직 (기존과 동일)
+                let adminApiError = '관리자 로그인 실패';
+                try {
+                    const errorData = await adminLoginResponse.json();
+                    adminApiError = errorData.detail || JSON.stringify(errorData);
+                } catch (jsonError) {
+                    adminApiError = `HTTP Error ${adminLoginResponse.status}: ${adminLoginResponse.statusText}`;
+                }
+                throw new Error(adminApiError);
+              }
+            
+              // 성공 응답 파싱
+              const adminData = await adminLoginResponse.json();
+              console.log("Admin Login Successful:", adminData);
+            
+              // 응답에서 access_token과 refresh_token 확인 -> API 명세와 일치
+              if (!adminData.access_token || !adminData.refresh_token) {
+                  throw new Error("관리자 로그인 응답에 토큰 정보가 없습니다.");
+              }
+            
+              // Zustand 스토어에 상태 저장 -> API 명세의 필드 이름과 일치
+              setAuthInfo({
+                  isAuthenticated: true,
+                  userRole: 'admin',
+                  accessToken: adminData.access_token,
+                  refreshToken: adminData.refresh_token
+              });
+              navigate('/admin/user/student'); // 리디렉션
+              break;
       }
 
     } catch (err: any) {


### PR DESCRIPTION
## 👀 이슈
resolve #20

## 📌 개요
로그인 시 access_token과 refresh_token저장, 이후 apiClient를 통해 접근 가능하도록 변경

## 👩‍💻 작업 사항

- 각 사용자 역할에 맞는 return 값 authStore에 저장
- API호출 시 apiClient를 통해 접근하고 만약 토큰 만료 시 token refresh로직 구현 완료